### PR TITLE
Fix failure on handling the path containing non-uri chars

### DIFF
--- a/lib/middleman-blog-drafts/draft_article.rb
+++ b/lib/middleman-blog-drafts/draft_article.rb
@@ -16,7 +16,8 @@ module Middleman
         # @param [String] The part of the path, e.g. "title"
         # @return [String]
         def path_part(part)
-          @_path_parts ||= blog_data.drafts.source_template.extract(path)
+          normalized_path = Addressable::URI.parse(path).normalize.to_s
+          @_path_parts ||= blog_data.drafts.source_template.extract(normalized_path)
           @_path_parts[part.to_s]
         end
 


### PR DESCRIPTION
In `DraftArticle#path_part`, `Addressable::Template#extract`
returns `nil` when `path` has characters not allowed for
URI (RFC3986) so that `DraftArticle#slug` fails for undefined `[]`.
Normalizing (percent-encoding) `path` string before `extract`
prevents its failure.

Characters outside the allowed set are Greek, Cyrillic or Japanese for example.
see http://www.ietf.org/rfc/rfc3986.txt
